### PR TITLE
Organize selectors

### DIFF
--- a/__tests__/components/cookie-banner-component.ts
+++ b/__tests__/components/cookie-banner-component.ts
@@ -1,6 +1,11 @@
+const SELECTORS = {
+    ACCEPT_ALL_BUTTON: "#acceptAllButton",
+};
+
 export class CookieBannerComponent {
     async attemptToClose(): Promise<void> {
-        const cookiesAlert = await browser.$("#acceptAllButton");
+        const { ACCEPT_ALL_BUTTON } = SELECTORS;
+        const cookiesAlert = await browser.$(ACCEPT_ALL_BUTTON);
         if (await cookiesAlert.isDisplayed()) {
             await cookiesAlert.waitAndClick();
         }

--- a/__tests__/components/messages-component.ts
+++ b/__tests__/components/messages-component.ts
@@ -1,75 +1,67 @@
 export const DEFAULT_URL =
     "https://paypal.github.io/paypal-sdk-e2e-tests/components/messages.html";
 
-export const messagesComponentSelectors = {
-    iframeMessageSelector: "iframe[name^='__zoid__paypal_message__']",
-    messageContainer: ".message[role='button",
-    iframeModalSelector: "iframe[name^='__zoid__paypal_credit_modal__']",
-    modalContainer: ".modal-wrapper",
-    modalCloseButton: "button.close",
+const SELECTORS = {
+    MESSAGE_IFRAME: "iframe[name^='__zoid__paypal_message__']",
+    MESSAGE_CONTAINER: ".message[role='button']",
+    MODAL_IFRAME: "iframe[name^='__zoid__paypal_credit_modal__']",
+    MODAL_CONTAINER: ".modal-wrapper",
+    MODAL_CLOSE_BUTTON: "button.close",
 };
 
 export class MessagesComponent {
     async switchToFrame(frameSelector: string): Promise<void> {
         browser.switchToParentFrame();
 
-        // wait for second render to complete
-        let frame = await $(frameSelector);
-        await frame.waitForDisplayed();
-
-        // reselect the frame to avoid the error "Could not switch frame, unknown id"
-        frame = await $(frameSelector);
+        const frame = await $(frameSelector);
         await frame.waitForDisplayed();
 
         if (!(await frame.isDisplayed())) {
             throw new Error(`Failed to load the iframe "${frameSelector}"`);
         }
 
-        frame = await $(frameSelector);
         await browser.switchToFrame(frame);
     }
 
     async switchToMessagesFrame(): Promise<void> {
-        const { iframeMessageSelector, messageContainer } =
-            messagesComponentSelectors;
+        const { MESSAGE_IFRAME, MESSAGE_CONTAINER } = SELECTORS;
 
-        let frameBody = await $(messageContainer);
+        let frameBody = await $(MESSAGE_CONTAINER);
 
         // first check and see if we are already in the frame
         if (await frameBody.isDisplayed()) {
             return;
         }
 
-        await this.switchToFrame(iframeMessageSelector);
+        await this.switchToFrame(MESSAGE_IFRAME);
 
         // wait for client-side render to complete
-        frameBody = await $(messageContainer);
+        frameBody = await $(MESSAGE_CONTAINER);
         await frameBody.waitForDisplayed();
     }
 
     async switchToModalFrame(): Promise<void> {
-        const { iframeModalSelector, modalContainer } =
-            messagesComponentSelectors;
+        const { MODAL_IFRAME, MODAL_CONTAINER } = SELECTORS;
 
-        let frameBody = await $(modalContainer);
+        let frameBody = await $(MODAL_CONTAINER);
 
         // first check and see if we are already in the frame
         if (await frameBody.isDisplayed()) {
             return;
         }
 
-        await this.switchToFrame(iframeModalSelector);
+        await this.switchToFrame(MODAL_IFRAME);
 
         // wait for client-side render to complete
-        frameBody = await $(modalContainer);
+        frameBody = await $(MODAL_CONTAINER);
         await frameBody.waitForDisplayed();
     }
 
     async click(): Promise<void> {
         await this.switchToMessagesFrame();
 
-        const { messageContainer } = messagesComponentSelectors;
-        const button = await $(messageContainer);
+        const { MESSAGE_CONTAINER } = SELECTORS;
+        const button = await $(MESSAGE_CONTAINER);
         await button.waitAndClick();
     }
 }

--- a/__tests__/components/unified-login-component.ts
+++ b/__tests__/components/unified-login-component.ts
@@ -1,5 +1,14 @@
 import { CookieBannerComponent } from "./cookie-banner-component";
 
+const SELECTORS = {
+    JAVASCRIPT_LOADED: "html.js",
+    EMAIL_INPUT: "#email",
+    PASSWORD_INPUT: "#password",
+    NEXT_BUTTON: "#btnNext",
+    LOGIN_BUTTON: "#btnLogin",
+    SECONDARY_LINK: ".secondaryLink a",
+};
+
 export class UnifiedLoginComponent {
     async loginWithEmailAndPassword(): Promise<void> {
         const { BUYER_EMAIL: email, BUYER_PASSWORD: password } = process.env;
@@ -7,11 +16,20 @@ export class UnifiedLoginComponent {
         if (!email || !password) throw new Error("Email and Password required");
         await this.isLoginFormReady();
 
+        const {
+            JAVASCRIPT_LOADED,
+            EMAIL_INPUT,
+            PASSWORD_INPUT,
+            NEXT_BUTTON,
+            SECONDARY_LINK,
+            LOGIN_BUTTON,
+        } = SELECTORS;
+
         // consider the page ready after js is loaded
-        const javascriptEnabled = await browser.$("html.js");
+        const javascriptEnabled = await browser.$(JAVASCRIPT_LOADED);
         javascriptEnabled.waitForDisplayed();
 
-        const emailInput = await browser.$("#email");
+        const emailInput = await browser.$(EMAIL_INPUT);
         await emailInput.waitForDisplayed();
         await emailInput.setValue(email);
 
@@ -20,14 +38,14 @@ export class UnifiedLoginComponent {
             await emailInput.setValue(email);
         }
 
-        const nextButton = await browser.$("#btnNext");
+        const nextButton = await browser.$(NEXT_BUTTON);
         await nextButton.waitAndClick();
 
         await browser.waitUntil(async () => {
-            const passwordInput = await browser.$("#password");
+            const passwordInput = await browser.$(PASSWORD_INPUT);
 
             // use the login with password option on the One Time code screen
-            const secondaryLink = await browser.$(".secondaryLink a");
+            const secondaryLink = await browser.$(SECONDARY_LINK);
 
             if (await passwordInput.isDisplayed()) {
                 return true;
@@ -37,14 +55,14 @@ export class UnifiedLoginComponent {
             return false;
         });
 
-        const passwordInput = await browser.$("#password");
+        const passwordInput = await browser.$(PASSWORD_INPUT);
         await passwordInput.waitForDisplayed();
         await passwordInput.setValue(password);
 
         const cookieBanner = new CookieBannerComponent();
         await cookieBanner.attemptToClose();
 
-        const loginButton = await browser.$("#btnLogin");
+        const loginButton = await browser.$(LOGIN_BUTTON);
         await loginButton.waitAndClick();
     }
 

--- a/__tests__/suites/login.test.ts
+++ b/__tests__/suites/login.test.ts
@@ -9,7 +9,6 @@ describe("login", () => {
         await browser.testUrl(DEFAULT_URL);
 
         const paypalButton = new ButtonsComponent(FUNDING.PAYPAL);
-        expect(await paypalButton.isLoaded()).to.be.equal(true);
 
         await paypalButton.click();
         await paypalButton.switchToPopupFrame();

--- a/__tests__/suites/messages-click.test.ts
+++ b/__tests__/suites/messages-click.test.ts
@@ -5,8 +5,8 @@ import {
     DEFAULT_URL,
 } from "../components/messages-component";
 
-describe("messages banner", () => {
-    it("clicking should launch the credit modal", async () => {
+describe("messages", () => {
+    it("should open the credit modal when clicking on the messages component", async () => {
         await browser.testUrl(DEFAULT_URL);
 
         const paypalMessagesComponent = new MessagesComponent();


### PR DESCRIPTION
This PR organizes the css selectors to the top of each component file. This helps improve readability and reuse. Keeping them private for now until we have a need to `export` and share them across files.