### PR TITLE
fix: simplify assertion for credit modal

### DIFF
--- a/tests/suites/messages-click.test.ts
+++ b/tests/suites/messages-click.test.ts
@@ -14,9 +14,7 @@ describe("messages", () => {
 
         await paypalMessagesComponent.switchToModalFrame();
 
-        const h1 = await $("h1");
-        const h1Text = await h1.getText();
-
-        expect(h1Text).to.equal("Buy now, pay later");
+        const pageTitle = await browser.getTitle();
+        expect(pageTitle).to.equal("Buy Now, Pay Later - PayPal");
     });
 });


### PR DESCRIPTION
It looks like there's A/B testing going on with the credit modal H1 value. Let's remove that assertion and keep it simple with only asserting on the `<title>` of the iframe credit modal.