### PR TITLE
feat(buttons): complete payment test

### DIFF
--- a/tests/suites/paypal-button-complete-payment.test.ts
+++ b/tests/suites/paypal-button-complete-payment.test.ts
@@ -1,0 +1,46 @@
+import { expect } from "chai";
+import { FUNDING } from "@paypal/sdk-constants";
+
+import { ButtonsComponent, DEFAULT_URL } from "../components/buttons-component";
+import { UnifiedLoginComponent } from "../components/unified-login-component";
+import { CookieBannerComponent } from "../components/cookie-banner-component";
+
+describe("paypal button", () => {
+    it("should complete payment with the paypal button", async () => {
+        await browser.testUrl(DEFAULT_URL);
+
+        const paypalButton = new ButtonsComponent(FUNDING.PAYPAL);
+
+        await paypalButton.click();
+        await paypalButton.switchToPopupFrame();
+
+        const unifiedLogin = new UnifiedLoginComponent();
+        await unifiedLogin.loginWithEmailAndPassword();
+
+        const isLoggedIn = await unifiedLogin.isLoggedIn();
+        expect(isLoggedIn).to.be.equal(true);
+
+        const SELECTORS = {
+            PAY_NOW_BUTTON: '[data-testid="submit-button-initial"]',
+            ON_APPROVE_SUCCESS_MESSAGE: "#output",
+        };
+
+        const cookieBanner = new CookieBannerComponent();
+        await cookieBanner.attemptToClose();
+
+        const payNowButton = await $(SELECTORS.PAY_NOW_BUTTON);
+        await payNowButton.waitForDisplayed();
+
+        await payNowButton.waitAndClick();
+
+        // switch back to the parent window context
+        const windows = await browser.getWindowHandles();
+        await browser.switchToWindow(windows[0]);
+
+        const onApproveMessage = await $(SELECTORS.ON_APPROVE_SUCCESS_MESSAGE);
+        await onApproveMessage.waitForDisplayed();
+        const messageText = await onApproveMessage.getText();
+
+        expect(messageText).to.be.equal("Thank you for your payment!");
+    });
+});


### PR DESCRIPTION
This new test covers the complete payment use case with the paypal button (PayPal Button click => SSO Login => Member Checkout => Back to Merchant Page).

This new test works great when testing in BrowerStack:
<img width="1108" alt="Screen Shot 2022-03-31 at 10 04 30 AM" src="https://user-images.githubusercontent.com/534034/161087869-efaaf238-b98e-4de7-9fb0-a8ff94ae74ec.png">
<img width="1094" alt="Screen Shot 2022-03-31 at 10 03 58 AM" src="https://user-images.githubusercontent.com/534034/161087885-9b2ff6bd-724d-4eca-81e0-a0748c1e9b29.png">

It does fail with the local runner so we will need to dig into that error more.
