### PR TITLE
feat: add test_url and local_testing to github actions workflow

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -2,7 +2,16 @@ name: BrowserStack Tests
 # manually run this action using the GitHub UI
 # https://github.blog/changelog/2020-07-06-github-actions-manual-triggers-with-workflow_dispatch/
 on:
-    workflow_dispatch: {}
+    workflow_dispatch:
+        inputs:
+            test_url:
+                description: Optional test url
+                required: false
+                default: ""
+            local_testing:
+                description: Enable local testing
+                required: false
+                type: boolean
     # run on push but only for the main branch
     push:
         branches: [main]
@@ -38,12 +47,12 @@ jobs:
             - name: ▶️ Run all tests
               id: test
               continue-on-error: true
-              run: BROWSERSTACK_BUILD_NAME="paypal-sdk-e2e-tests-$GITHUB_RUN_ID" BUYER_EMAIL=${{ secrets.BUYER_EMAIL }} BUYER_PASSWORD=${{ secrets.BUYER_PASSWORD }} TEST_URL="${{ github.event.inputs.filter }}" npm run test-browserstack
+              run: BROWSERSTACK_BUILD_NAME="paypal-sdk-e2e-tests-$GITHUB_RUN_ID" BUYER_EMAIL=${{ secrets.BUYER_EMAIL }} BUYER_PASSWORD=${{ secrets.BUYER_PASSWORD }} TEST_URL="${{ github.event.inputs.test_url }}" LOCAL_TESTING=${{ github.event.inputs.local_testing }} npm run test-browserstack
 
             - name: ▶️ Run IP Geolocation tests for Germany
               id: test_germany
               continue-on-error: true
-              run: BROWSERSTACK_BUILD_NAME="paypal-sdk-e2e-tests-germany-$GITHUB_RUN_ID" BUYER_EMAIL=${{ secrets.BUYER_EMAIL }} BUYER_PASSWORD=${{ secrets.BUYER_PASSWORD }} TEST_URL="${{ github.event.inputs.filter }}" npm run test-browserstack-german -- --spec card-button-text
+              run: BROWSERSTACK_BUILD_NAME="paypal-sdk-e2e-tests-germany-$GITHUB_RUN_ID" BUYER_EMAIL=${{ secrets.BUYER_EMAIL }} BUYER_PASSWORD=${{ secrets.BUYER_PASSWORD }} TEST_URL="${{ github.event.inputs.test_url }}" LOCAL_TESTING=${{ github.event.inputs.local_testing }} npm run test-browserstack-german -- --spec card-button-text
 
             - name: 🤞 Check if tests have passed
               if: steps.test.outcome == 'failure' || steps.test_germany.outcome == 'failure'


### PR DESCRIPTION
### Purpose

This PR adds `TEST_URL` and `LOCAL_TESTING` to the GitHub Actions workflow. This allows anyone with repo permissions to run the e2e tests using a non-default test page, including test pages with test environment scripts.

### Testing

This change will be fully tested after getting merged (not sure how to do so otherwise).