### PR TITLE
fix: update expected messages text

### DIFF
--- a/tests/suites/messages-click.test.ts
+++ b/tests/suites/messages-click.test.ts
@@ -21,6 +21,7 @@ describe("messages", () => {
             "Buy now, pay later",
             "Pay in 4 interest-free payments",
             "Pay over time with PayPal Credit",
+            "Pay with monthly installments",
         ];
 
         expect(possibleHeadings).to.include(h1Text);


### PR DESCRIPTION
### Purpose

This PR updates the expected messages `h1` text. The tests pass after this change: https://automate.browserstack.com/dashboard/v2/builds/c052987641facdbb4d8beff0c031f27126781da4