### PR TITLE
feat: add messages url

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -5,7 +5,7 @@ on:
     workflow_dispatch:
         inputs:
             buttons_url:
-                description: Optional test url
+                description: Optional buttons url
                 required: false
                 default: ""
             messages_url:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -8,6 +8,10 @@ on:
                 description: Optional test url
                 required: false
                 default: ""
+            messages_url:
+                description: Optional messages url
+                required: false
+                default: ""
             local_testing:
                 description: Enable local testing
                 required: false
@@ -47,12 +51,12 @@ jobs:
             - name: ▶️ Run all tests
               id: test
               continue-on-error: true
-              run: BROWSERSTACK_BUILD_NAME="paypal-sdk-e2e-tests-$GITHUB_RUN_ID" BUYER_EMAIL=${{ secrets.BUYER_EMAIL }} BUYER_PASSWORD=${{ secrets.BUYER_PASSWORD }} TEST_URL="${{ github.event.inputs.test_url }}" LOCAL_TESTING=${{ github.event.inputs.local_testing }} npm run test-browserstack
+              run: BROWSERSTACK_BUILD_NAME="paypal-sdk-e2e-tests-$GITHUB_RUN_ID" BUYER_EMAIL=${{ secrets.BUYER_EMAIL }} BUYER_PASSWORD=${{ secrets.BUYER_PASSWORD }} TEST_URL="${{ github.event.inputs.test_url }}" MESSAGES_URL="${{ github.event.inputs.messages_url }}" LOCAL_TESTING=${{ github.event.inputs.local_testing }} npm run test-browserstack
 
             - name: ▶️ Run IP Geolocation tests for Germany
               id: test_germany
               continue-on-error: true
-              run: BROWSERSTACK_BUILD_NAME="paypal-sdk-e2e-tests-germany-$GITHUB_RUN_ID" BUYER_EMAIL=${{ secrets.BUYER_EMAIL }} BUYER_PASSWORD=${{ secrets.BUYER_PASSWORD }} TEST_URL="${{ github.event.inputs.test_url }}" LOCAL_TESTING=${{ github.event.inputs.local_testing }} npm run test-browserstack-german -- --spec card-button-text
+              run: BROWSERSTACK_BUILD_NAME="paypal-sdk-e2e-tests-germany-$GITHUB_RUN_ID" BUYER_EMAIL=${{ secrets.BUYER_EMAIL }} BUYER_PASSWORD=${{ secrets.BUYER_PASSWORD }} TEST_URL="${{ github.event.inputs.test_url }}" MESSAGES_URL="${{ github.event.inputs.messages_url }}" LOCAL_TESTING=${{ github.event.inputs.local_testing }} npm run test-browserstack-german -- --spec card-button-text
 
             - name: 🤞 Check if tests have passed
               if: steps.test.outcome == 'failure' || steps.test_germany.outcome == 'failure'

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -4,7 +4,7 @@ name: BrowserStack Tests
 on:
     workflow_dispatch:
         inputs:
-            test_url:
+            buttons_url:
                 description: Optional test url
                 required: false
                 default: ""
@@ -51,12 +51,12 @@ jobs:
             - name: ▶️ Run all tests
               id: test
               continue-on-error: true
-              run: BROWSERSTACK_BUILD_NAME="paypal-sdk-e2e-tests-$GITHUB_RUN_ID" BUYER_EMAIL=${{ secrets.BUYER_EMAIL }} BUYER_PASSWORD=${{ secrets.BUYER_PASSWORD }} TEST_URL="${{ github.event.inputs.test_url }}" MESSAGES_URL="${{ github.event.inputs.messages_url }}" LOCAL_TESTING=${{ github.event.inputs.local_testing }} npm run test-browserstack
+              run: BROWSERSTACK_BUILD_NAME="paypal-sdk-e2e-tests-$GITHUB_RUN_ID" BUYER_EMAIL=${{ secrets.BUYER_EMAIL }} BUYER_PASSWORD=${{ secrets.BUYER_PASSWORD }} BUTTONS_URL="${{ github.event.inputs.buttons_url }}" MESSAGES_URL="${{ github.event.inputs.messages_url }}" LOCAL_TESTING=${{ github.event.inputs.local_testing }} npm run test-browserstack
 
             - name: ▶️ Run IP Geolocation tests for Germany
               id: test_germany
               continue-on-error: true
-              run: BROWSERSTACK_BUILD_NAME="paypal-sdk-e2e-tests-germany-$GITHUB_RUN_ID" BUYER_EMAIL=${{ secrets.BUYER_EMAIL }} BUYER_PASSWORD=${{ secrets.BUYER_PASSWORD }} TEST_URL="${{ github.event.inputs.test_url }}" MESSAGES_URL="${{ github.event.inputs.messages_url }}" LOCAL_TESTING=${{ github.event.inputs.local_testing }} npm run test-browserstack-german -- --spec card-button-text
+              run: BROWSERSTACK_BUILD_NAME="paypal-sdk-e2e-tests-germany-$GITHUB_RUN_ID" BUYER_EMAIL=${{ secrets.BUYER_EMAIL }} BUYER_PASSWORD=${{ secrets.BUYER_PASSWORD }} BUTTONS_URL="${{ github.event.inputs.buttons_url }}" MESSAGES_URL="${{ github.event.inputs.messages_url }}" LOCAL_TESTING=${{ github.event.inputs.local_testing }} npm run test-browserstack-german -- --spec card-button-text
 
             - name: 🤞 Check if tests have passed
               if: steps.test.outcome == 'failure' || steps.test_germany.outcome == 'failure'

--- a/README.md
+++ b/README.md
@@ -43,10 +43,10 @@ The tests run against the following default urls:
 -   buttons: https://paypal.github.io/paypal-sdk-e2e-tests/components/buttons/buttons.html
 -   messages: https://paypal.github.io/paypal-sdk-e2e-tests/components/messages/messages.html
 
-These urls can be overriden using the `TEST_URL` and `MESSAGES_URL` environment variables to test the JS SDK on different websites. For example, the button tests can be run against the react-paypal-js storybook demo:
+These urls can be overriden using the `BUTTONS_URL` and `MESSAGES_URL` environment variables to test the JS SDK on different websites. For example, the button tests can be run against the react-paypal-js storybook demo:
 
 ```bash
-TEST_URL="https://paypal.github.io/react-paypal-js/iframe.html?id=example-paypalbuttons--default&args=&viewMode=story" npm test -- --spec button
+BUTTONS_URL="https://paypal.github.io/react-paypal-js/iframe.html?id=example-paypalbuttons--default&args=&viewMode=story" npm test -- --spec button
 ```
 
 ### BrowserStack local testing from the command line
@@ -60,5 +60,5 @@ LOCAL_TESTING=true npm run test-browserstack
 This is useful for running tests using `localhost` and/or a test page that uses a custom JS SDK test environment:
 
 ```bash
-TEST_URL="https://paypal.github.io/paypal-sdk-e2e-tests/components/buttons/buttons.html?client-id=<client-id>&sdkBaseURL=<js-sdk-test-env-url>" LOCAL_TESTING=true npm run test-browserstack
+BUTTONS_URL="https://paypal.github.io/paypal-sdk-e2e-tests/components/buttons/buttons.html?client-id=<client-id>&sdkBaseURL=<js-sdk-test-env-url>" LOCAL_TESTING=true npm run test-browserstack
 ```

--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ The tests run against the following default urls:
 -   buttons: https://paypal.github.io/paypal-sdk-e2e-tests/components/buttons/buttons.html
 -   messages: https://paypal.github.io/paypal-sdk-e2e-tests/components/messages/messages.html
 
-This url can be overriden using the `TEST_URL` environment variable to test the JS SDK on different websites. For example, the button tests can be run against the react-paypal-js storybook demo:
+These urls can be overriden using the `TEST_URL` and `MESSAGES_URL` environment variables to test the JS SDK on different websites. For example, the button tests can be run against the react-paypal-js storybook demo:
 
 ```bash
 TEST_URL="https://paypal.github.io/react-paypal-js/iframe.html?id=example-paypalbuttons--default&args=&viewMode=story" npm test -- --spec button

--- a/resources/config/wdio.conf.ts
+++ b/resources/config/wdio.conf.ts
@@ -32,9 +32,9 @@ export const config = {
     },
     before: function (): void {
         browser.addCommand(
-            "testUrl",
+            "buttonsUrl",
             function (defaultUrl: string): Promise<string> {
-                return this.url(process.env.TEST_URL || defaultUrl);
+                return this.url(process.env.BUTTONS_URL || defaultUrl);
             }
         );
 

--- a/resources/config/wdio.conf.ts
+++ b/resources/config/wdio.conf.ts
@@ -39,6 +39,13 @@ export const config = {
         );
 
         browser.addCommand(
+            "messagesUrl",
+            function (defaultUrl: string): Promise<string> {
+                return this.url(process.env.MESSAGES_URL || defaultUrl);
+            }
+        );
+
+        browser.addCommand(
             "waitAndClick",
             async function (): Promise<void> {
                 await this.waitForDisplayed();

--- a/tests/suites/card-button-click.test.ts
+++ b/tests/suites/card-button-click.test.ts
@@ -5,7 +5,7 @@ import { ButtonsComponent, DEFAULT_URL } from "../components/buttons-component";
 
 describe("card button", () => {
     it("should show the inline guest form when clicking on the card button", async () => {
-        await browser.testUrl(DEFAULT_URL);
+        await browser.buttonsUrl(DEFAULT_URL);
 
         const cardButtonComponent = new ButtonsComponent(FUNDING.CARD);
 

--- a/tests/suites/card-button-text.test.ts
+++ b/tests/suites/card-button-text.test.ts
@@ -22,7 +22,7 @@ async function getBrowserLanguage(): Promise<string> {
 
 describe("card button", () => {
     it(`should display the card button text based on the browser language`, async () => {
-        await browser.testUrl(DEFAULT_URL);
+        await browser.buttonsUrl(DEFAULT_URL);
 
         const cardButtonComponent = new ButtonsComponent(FUNDING.CARD);
 

--- a/tests/suites/login.test.ts
+++ b/tests/suites/login.test.ts
@@ -6,7 +6,7 @@ import { UnifiedLoginComponent } from "../components/unified-login-component";
 
 describe("login", () => {
     it("should log in with an email and password", async () => {
-        await browser.testUrl(DEFAULT_URL);
+        await browser.buttonsUrl(DEFAULT_URL);
 
         const paypalButton = new ButtonsComponent(FUNDING.PAYPAL);
 

--- a/tests/suites/messages-click.test.ts
+++ b/tests/suites/messages-click.test.ts
@@ -7,7 +7,7 @@ import {
 
 describe("messages", () => {
     it("should open the credit modal when clicking on the messages component", async () => {
-        await browser.testUrl(DEFAULT_URL);
+        await browser.messagesUrl(DEFAULT_URL);
 
         const paypalMessagesComponent = new MessagesComponent();
         await paypalMessagesComponent.click();

--- a/tests/suites/paylater-button-click.test.ts
+++ b/tests/suites/paylater-button-click.test.ts
@@ -6,7 +6,7 @@ import { UnifiedLoginComponent } from "../components/unified-login-component";
 
 describe("paylater button", () => {
     it("should open the popup when clicking on the paylater button", async () => {
-        await browser.testUrl(DEFAULT_URL);
+        await browser.buttonsUrl(DEFAULT_URL);
 
         const paypalButtonComponent = new ButtonsComponent(FUNDING.PAYLATER);
         await paypalButtonComponent.click();

--- a/tests/suites/paypal-button-click.test.ts
+++ b/tests/suites/paypal-button-click.test.ts
@@ -6,7 +6,7 @@ import { UnifiedLoginComponent } from "../components/unified-login-component";
 
 describe("paypal button", () => {
     it("should open the popup when clicking on the paypal button", async () => {
-        await browser.testUrl(DEFAULT_URL);
+        await browser.buttonsUrl(DEFAULT_URL);
 
         const paypalButtonComponent = new ButtonsComponent(FUNDING.PAYPAL);
         await paypalButtonComponent.click();

--- a/tests/suites/paypal-button-complete-payment.test.ts
+++ b/tests/suites/paypal-button-complete-payment.test.ts
@@ -7,7 +7,7 @@ import { CookieBannerComponent } from "../components/cookie-banner-component";
 
 describe("paypal button", () => {
     it("should complete payment with the paypal button", async () => {
-        await browser.testUrl(DEFAULT_URL);
+        await browser.buttonsUrl(DEFAULT_URL);
 
         const paypalButton = new ButtonsComponent(FUNDING.PAYPAL);
 

--- a/tests/types/wdio.d.ts
+++ b/tests/types/wdio.d.ts
@@ -4,5 +4,6 @@ declare namespace WebdriverIO {
     }
     interface Browser {
         buttonsUrl: (defaultUrl: string) => Promise<string>;
+        messagesUrl: (defaultUrl: string) => Promise<string>;
     }
 }

--- a/tests/types/wdio.d.ts
+++ b/tests/types/wdio.d.ts
@@ -3,6 +3,6 @@ declare namespace WebdriverIO {
         waitAndClick: () => Promise<void>;
     }
     interface Browser {
-        testUrl: (defaultUrl: string) => Promise<string>;
+        buttonsUrl: (defaultUrl: string) => Promise<string>;
     }
 }


### PR DESCRIPTION
### Purpose

This PR adds a customizable messages URL (`MESSAGES_URL`), and makes it possible to avoid overriding the default messages URL when customizing the buttons URL (this was formerly known as `TEST_URL`, but has been renamed `BUTTONS_URL` to clarify the meaning/usage).  