### PR TITLE
fix: increase timeout value

### DIFF
--- a/resources/config/wdio.conf.ts
+++ b/resources/config/wdio.conf.ts
@@ -9,7 +9,7 @@ export const config = {
     logLevel: "warn",
     coloredLogs: true,
     bail: 0,
-    waitforTimeout: 30000,
+    waitforTimeout: 60000,
     connectionRetryTimeout: 120000,
     chromeOptions: {
         prefs: {


### PR DESCRIPTION
### Purpose

This PR increases the `waitforTimeout` value, which helps reduce test failures in stage environments due to timeouts. It's not perfect, but does seem to help. The only downside is if a test still fails due to a timeout, it takes longer to do so. Removing `&debug=true` from the script helps too, but that's up to the tester.